### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) server for interacting with Helm charts on [Artifacthub](https://artifacthub.io/).
 
+<a href="https://glama.ai/mcp/servers/@AlexW00/artifacthub-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AlexW00/artifacthub-mcp/badge" alt="ArtifactHub Server MCP server" />
+</a>
+
 ## Usage
 
 For VS-Code, click this [auto-install-link](https://insiders.vscode.dev/redirect/mcp/install?name=artifacthub-mcp&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22ghcr.io%2Falexw00%2Fartifacthub-mcp%3Alatest%22%5D%7D).


### PR DESCRIPTION
This PR adds a badge for the [ArtifactHub MCP Server](https://glama.ai/mcp/servers/@AlexW00/artifacthub-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@AlexW00/artifacthub-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AlexW00/artifacthub-mcp/badge" alt="ArtifactHub Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.